### PR TITLE
Add a test for alphanumeric selects

### DIFF
--- a/tests_rv/patch/alphanumeric_selects/alphanumeric_selects.sh
+++ b/tests_rv/patch/alphanumeric_selects/alphanumeric_selects.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+
+tmpfile_b=$(mktemp)
+tmpfile_n=$(mktemp)
+
+rc=1
+
+HEAD=$(git rev-parse HEAD)
+
+git checkout -q HEAD~
+
+../../tests_rv/patch/alphanumeric_selects/alphanumeric_selects.pl arch/riscv/Kconfig > $tmpfile_b
+
+before=$(diff -y  --suppress-common-lines $tmpfile_b arch/riscv/Kconfig | wc -l)
+
+git checkout -q $HEAD
+
+../../tests_rv/patch/alphanumeric_selects/alphanumeric_selects.pl arch/riscv/Kconfig > $tmpfile_n
+
+now=$(diff -y  --suppress-common-lines $tmpfile_n arch/riscv/Kconfig | wc -l)
+
+echo "Out of order selects before the patch: $before and now $now" >&$DESC_FD
+
+if [ $now -gt $before ]; then
+  echo "New out of order selects added" 1>&2
+  diff -U 0 $tmpfile_b $tmpfile_n
+else
+  rc=0
+fi
+
+rm -rf $tmpfile_b $tmpfile_n
+exit $rc

--- a/tests_rv/patch/alphanumeric_selects/info.json
+++ b/tests_rv/patch/alphanumeric_selects/info.json
@@ -1,0 +1,4 @@
+{
+  "run": ["alphanumeric_selects.sh"],
+  "pull-requests": true
+}


### PR DESCRIPTION
@Bjorn, perhaps you know - are scripts that are in the kernels git logs GPLv2? I figure they would be.

Anyway, I have not actually tested the script as part of nipa itself but it does seem to work as a script in isolation.