### PR TITLE
rv: pw_poller: be more specific about tree selection errors

### DIFF
--- a/pw_poller.py
+++ b/pw_poller.py
@@ -113,7 +113,7 @@ class PwPoller:
             res = f"Guessed tree name to be {s.tree_name}"
         else:
             log("Target tree not found", "")
-            res = "Guessing tree name failed"
+            res = "Failed to apply to next/pending-fixes or riscv/for-next"
 
         return res
 


### PR DESCRIPTION
Atish pointed out that the current message the message is kinda misleading - he did not realise that it meant the patch did not apply nor which trees we tried. Explicitly mention the trees in the error text.

Signed-off-by: Conor Dooley <conor.dooley@microchip.com>