### PR TITLE
rv: add a test for bad patterns in MAINTAINERS

### DIFF
--- a/tests_rv/patch/maintainers_pattern/info.json
+++ b/tests_rv/patch/maintainers_pattern/info.json
@@ -1,0 +1,4 @@
+{
+  "run": ["maintainers_patterns.sh"],
+  "pull-requests": true
+}

--- a/tests_rv/patch/maintainers_pattern/maintainers_patterns.sh
+++ b/tests_rv/patch/maintainers_pattern/maintainers_patterns.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+
+tmpfile_b=$(mktemp)
+tmpfile_n=$(mktemp)
+
+rc=1
+
+HEAD=$(git rev-parse HEAD)
+
+git checkout -q HEAD~
+
+./scripts/get_maintainer.pl --self-test=patterns > $tmpfile_b
+
+before=$(cat $tmpfile_b | wc -l)
+
+git checkout -q $HEAD
+
+./scripts/get_maintainer.pl --self-test=patterns > $tmpfile_n
+
+now=$(cat $tmpfile_n | wc -l)
+
+echo "MAINTAINERS pattern errors before the patch: $before and now $now" >&$DESC_FD
+
+if [ $now -gt $before ]; then
+  echo "New pattern errors added, run ./scripts/get_maintainer.pl --self-test=patterns for more info" 1>&2
+else
+  rc=0
+fi
+
+rm -rf $tmpfile_b $tmpfile_n
+
+exit $rc


### PR DESCRIPTION
I thought of this one today, scrolling LKML and seeing Lukas Bulwahn's name. It's been useful to me, so may as well start running it here JIC.

This has caught me out a bunch and I run it in my hacked-up Makefile stuff. Run it in NIPA-RV too as it's an easy mistake to make!
