### PR TITLE
cover letter/patch count test changes

### DIFF
--- a/tests_rv/series/cover_letter/test.py
+++ b/tests_rv/series/cover_letter/test.py
@@ -15,4 +15,4 @@ def cover_letter(tree, thing, result_dir) -> Tuple[int, str]:
     # feature + selftest postings where commit message of the feature is definitive
     if len(thing.patches) < 3:
         return 0, "Single patches do not need cover letters"
-    return 250, "Series does not have a cover letter"
+    return 1, "Series does not have a cover letter"

--- a/tests_rv/series/patch_count/info.json
+++ b/tests_rv/series/patch_count/info.json
@@ -1,4 +1,5 @@
 {
   "pymod": "test",
-  "pyfunc": "patch_count"
+  "pyfunc": "patch_count",
+  "disabled": true
 }


### PR DESCRIPTION
See #11 for context. Patch count being enforced is a netdev-ism, which may not be valid for us.

netdev only warn when a cover letter is missing, but really cover letters for multi-patch series should be a requirement.
Upgrade it  from a warning to an error.