### PR TITLE
rv: fix the poller being broken by a parse error!

### DIFF
--- a/tests_rv/patch/build_rv64_clang_allmodconfig/info.json
+++ b/tests_rv/patch/build_rv64_clang_allmodconfig/info.json
@@ -1,4 +1,4 @@
 {
   "run": ["build_rv64_clang_allmodconfig.sh"],
-  "pull-requests": true,
+  "pull-requests": true
 }


### PR DESCRIPTION
If I'd written this patch in nvim initially, I would have noticed it complaining about the trailing ,. I guess I must have written it in vscode over ssh from my windows work laptop...

Signed-off-by: Conor Dooley <conor.dooley@microchip.com>

@bjoto I'm going to force merge this one...