### PR TITLE
treewide: allow dependency selection in a cover letter

### DIFF
--- a/core/series.py
+++ b/core/series.py
@@ -43,3 +43,21 @@ class Series(object):
 
     def is_pure_pull(self):
         return bool(self.pull_url)
+
+    def depends_from_cover(self):
+        if not self.cover_letter:
+            return False
+
+        depends_section = re.compile(r'(?:based.on|depends.on|depend(?:a|e)ncies):\n(?:\S+@\S+\n)*', re.IGNORECASE | re.MULTILINE)
+        depends = re.compile(r'\S+@\S+', re.IGNORECASE)
+        match = depends_section.search(self.cover_letter)
+
+        if not match:
+            # fall back to patchew's git trailer style & try that
+            patchew_section = re.compile(r'(?:based.on: \S+@\S+\n)+', re.IGNORECASE | re.MULTILINE)
+            match = patchew_section.search(self.cover_letter)
+
+        if match:
+            return depends.findall(match.group(0))
+
+        return False

--- a/core/tester.py
+++ b/core/tester.py
@@ -157,13 +157,20 @@ class Tester(threading.Thread):
                     fp.write("0")
                 with open(os.path.join(series_apply, "desc"), "w+") as fp:
                     fp.write(f"Patch already applied to {tree.name}")
+                return [already_applied], [already_applied]
             else:
                 core.log("Series does not apply", "")
-                with open(os.path.join(series_apply, "retcode"), "w+") as fp:
-                    fp.write("1")
-                with open(os.path.join(series_apply, "desc"), "w+") as fp:
-                    fp.write(f"Patch does not apply to {tree.name}")
-            return [already_applied], [already_applied]
+                if not tree.check_applies_with_depends(series):
+                    with open(os.path.join(series_apply, "retcode"), "w+") as fp:
+                        fp.write("1")
+                    with open(os.path.join(series_apply, "desc"), "w+") as fp:
+                        fp.write(f"Patch does not apply to {tree.name}")
+                    return [already_applied], [already_applied]
+                else:
+                    with open(os.path.join(series_apply, "retcode"), "w+") as fp:
+                        fp.write("0")
+                    with open(os.path.join(series_apply, "desc"), "w+") as fp:
+                        fp.write(f"Patch does not apply to {tree.name} without dependencies")
 
         series_ret = []
         patch_ret = []

--- a/ingest_mdir.py
+++ b/ingest_mdir.py
@@ -65,6 +65,8 @@ finally:
 tree = Tree(args.tree_name, args.tree_name, args.tree, branch=args.tree_branch)
 if not tree.check_applies(series):
     print("Patch series does not apply cleanly to the tree")
+    if tree.check_applies_with_depends(series):
+        print("woo!")
     os.sys.exit(1)
 
 try:

--- a/pw_poller.py
+++ b/pw_poller.py
@@ -105,8 +105,13 @@ class PwPoller:
 
         if "fixes" in self._trees and netdev.series_is_a_fix_for(s, self._trees["fixes"]):
             s.tree_name = "fixes"
-        elif "for-next" in self._trees and self._trees["for-next"].check_applies(s):
-            s.tree_name = "for-next"
+        elif "for-next" in self._trees:
+            if self._trees["for-next"].check_applies(s):
+                s.tree_name = "for-next"
+            elif self._trees["for-next"].check_applies_with_depends(s):
+                s.tree_name = "for-next"
+                log(f"Target tree - {s.tree_name} (with dependencies)", "")
+                return "Guessed tree name to be for-next, with dependencies"
 
         if hasattr(s, 'tree_name') and s.tree_name:
             log(f"Target tree - {s.tree_name}", "")


### PR DESCRIPTION
A lot of series depend on other bits that are in motion, so provide a way for such dependencies to be specificity in a cover letter. The expected format is a line containing "depends on:" followed by lore links to the dependencies. Eg:
depends on:

The regex "(?:depends on|depend(?:a|e)ncies):\n(?:\S+@\S+\n)*" is used to match the line and subsequent links.
Any such matching is best-effort only, and really patchsets should be based on the fixes, master or for-next branches of the riscv tree.

This was suggested by @jones-drew & I finally got around to giving it a proper go. I've tested this on my internal patchwork instance & it looks good...