### PR TITLE
rv: (try to) fix log output for failed builds

### DIFF
--- a/tests_rv/patch/build_rv32_defconfig/build_rv32_defconfig.sh
+++ b/tests_rv/patch/build_rv32_defconfig/build_rv32_defconfig.sh
@@ -16,7 +16,7 @@ tuxmake --wrapper ccache --target-arch riscv --directory . \
 
 if [ $rc -ne 0 ]; then
 	echo "Build failed" >&$DESC_FD
-	grep "\(warning\|error\):" $tmpfile_n >&2
+	grep "\(warning\|error\):" $tmpfile >&2
 else
 	echo "Build OK" >&$DESC_FD
 fi

--- a/tests_rv/patch/build_rv64_clang_allmodconfig/build_rv64_clang_allmodconfig.sh
+++ b/tests_rv/patch/build_rv64_clang_allmodconfig/build_rv64_clang_allmodconfig.sh
@@ -5,6 +5,7 @@
 
 # Modified tests/patch/build_defconfig_warn.sh for RISC-V builds
 
+tmpfile_e=$(mktemp)
 tmpfile_o=$(mktemp)
 tmpfile_n=$(mktemp)
 
@@ -29,13 +30,13 @@ tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
 	-K CONFIG_WERROR=n -K CONFIG_RANDSTRUCT_NONE=y W=1 \
 	CROSS_COMPILE=riscv64-linux- \
 	config default \
-	|| rc=1
+	> $tmpfile_e || rc=1
 
 if [ $rc -eq 1 ]
 then
 	echo "Failed to build the tree with this patch." >&$DESC_FD
-	grep "\(error\):" $tmpfile_n >&2
-	rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
+	grep "\(error\):" $tmpfile_e >&2
+	rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
 	exit $rc
 fi
 
@@ -108,6 +109,6 @@ if [ $current -gt $incumbent ]; then
   rc=1
 fi
 
-rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
+rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
 
 exit $rc

--- a/tests_rv/patch/build_rv64_gcc_allmodconfig/build_rv64_gcc_allmodconfig.sh
+++ b/tests_rv/patch/build_rv64_gcc_allmodconfig/build_rv64_gcc_allmodconfig.sh
@@ -5,6 +5,7 @@
 
 # Modified tests/patch/build_defconfig_warn.sh for RISC-V builds
 
+tmpfile_e=$(mktemp)
 tmpfile_o=$(mktemp)
 tmpfile_n=$(mktemp)
 
@@ -29,13 +30,13 @@ tuxmake --wrapper ccache --target-arch riscv -e PATH=$PATH --directory . \
 	-K CONFIG_WERROR=n -K CONFIG_GCC_PLUGINS=n W=1 \
 	CROSS_COMPILE=riscv64-linux- \
 	config default \
-	|| rc=1
+	> $tmpfile_e || rc=1
 
 if [ $rc -eq 1 ]
 then
 	echo "Failed to build the tree with this patch." >&$DESC_FD
-	grep "\(error\):" $tmpfile_n >&2
-	rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
+	grep "\(error\):" $tmpfile_e >&2
+	rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
 	exit $rc
 fi
 
@@ -106,6 +107,6 @@ if [ $current -gt $incumbent ]; then
   rc=1
 fi
 
-rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b
+rm -rf $tmpdir_o $tmpfile_o $tmpfile_n $tmpdir_b $tmpfile_e
 
 exit $rc

--- a/tests_rv/patch/build_rv64_nommu_k210_defconfig/build_rv64_nommu_k210_defconfig.sh
+++ b/tests_rv/patch/build_rv64_nommu_k210_defconfig/build_rv64_nommu_k210_defconfig.sh
@@ -4,20 +4,23 @@
 # Copyright (c) 2022 by Rivos Inc.
 
 tmpdir=$(mktemp -d)
+tmpfile=$(mktemp)
 rc=0
 
 tuxmake --wrapper ccache --target-arch riscv --directory . \
         --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir --toolchain gcc -z none -k nommu_k210_defconfig \
-	CROSS_COMPILE=riscv64-linux- || rc=1
+        CROSS_COMPILE=riscv64-linux- \
+        > $tmpfile || rc=1
 
 if [ $rc -ne 0 ]; then
   echo "Build failed" >&$DESC_FD
+  grep "\(warning\|error\):" $tmpfile >&2
 else
   echo "Build OK" >&$DESC_FD
 fi
 
-rm -rf $tmpdir
+rm -rf $tmpdir $tmpfile
 
 exit $rc

--- a/tests_rv/patch/build_rv64_nommu_virt_defconfig/build_rv64_nommu_virt_defconfig.sh
+++ b/tests_rv/patch/build_rv64_nommu_virt_defconfig/build_rv64_nommu_virt_defconfig.sh
@@ -4,20 +4,23 @@
 # Copyright (c) 2022 by Rivos Inc.
 
 tmpdir=$(mktemp -d)
+tmpfile=$(mktemp)
 rc=0
 
 tuxmake --wrapper ccache --target-arch riscv --directory . \
         --environment=KBUILD_BUILD_TIMESTAMP=@1621270510 \
         --environment=KBUILD_BUILD_USER=tuxmake --environment=KBUILD_BUILD_HOST=tuxmake \
         -o $tmpdir --toolchain gcc -z none -k nommu_virt_defconfig \
-	CROSS_COMPILE=riscv64-linux- || rc=1
+        CROSS_COMPILE=riscv64-linux- \
+        > $tmpfile || rc=1
 
 if [ $rc -ne 0 ]; then
   echo "Build failed" >&$DESC_FD
+  grep "\(warning\|error\):" $tmpfile >&2
 else
   echo "Build OK" >&$DESC_FD
 fi
 
-rm -rf $tmpdir
+rm -rf $tmpdir $tmpfile
 
 exit $rc


### PR DESCRIPTION
When the initial build fails, we go and break out of the test immediately, and in some cases print the error.
The issue though is that in the cases that we do actually try to print the error, we use an empty file as $tmpfile_n is not populated until later.
Add either /a/ file or a /new/ file, depending on the test, that will hold the output from the initial build & print that out in the basic failure case. rv32_defconfig builds already have a file collecting this information, so print that rather than adding something new.