### PR TITLE
Fix the dependency stuff entirely breaking the poller

### DIFF
--- a/core/tree.py
+++ b/core/tree.py
@@ -164,7 +164,6 @@ class Tree:
             try:
                 CMD.cmd_run(command, cwd=self.path)
             except CMD.CmdError as e:
-                print(f"failed! {e}")
                 try:
                     self.git(["am", "--abort"])
                 except CMD.CmdError:
@@ -194,13 +193,15 @@ class Tree:
         return ret
 
     def check_applies_with_depends(self, thing):
-        core.log_open_sec("Test-applying " + thing.title)
+        core.log_open_sec("Test-applying (with pre-reqs) " + thing.title)
         try:
             self.reset()
 
             if hasattr(thing, "cover_letter"):
+                core.log_open_sec(thing.title + " has a cover, checking pre-reqs")
                 depends = thing.depends_from_cover()
                 if depends:
+                    core.log_open_sec("Applying pre-reqs for " + thing.title)
                     self.apply_prereqs(depends)
 
             self.apply(thing)

--- a/core/tree.py
+++ b/core/tree.py
@@ -160,7 +160,7 @@ class Tree:
 
     def apply_prereqs(self, prereqs):
         for link in prereqs:
-            command = ["/stuff/b4/b4.sh", "shazam", link]
+            command = ["b4", "shazam", link]
             try:
                 CMD.cmd_run(command, cwd=self.path)
             except CMD.CmdError as e:


### PR DESCRIPTION
On my system b4 is a bash alias to the script not an executable.
On my CI boxes, it's a regular executable. D'oh.

I'm just gonna go and merge this now.